### PR TITLE
Handle CMTIME_IS_INDEFINITE for duration changes

### DIFF
--- a/ios/AwsIvsAdapterPlayerView.m
+++ b/ios/AwsIvsAdapterPlayerView.m
@@ -90,10 +90,12 @@ static const NSInteger kDefaultMaxBufferTimeInSeconds = 10;
 }
 
 - (void)player:(IVSPlayer *)player didChangeDuration:(CMTime)duration {
-    NSLog(@"Changed duration to %@", @(CMTimeGetSeconds(duration)));
+    if (!CMTIME_IS_INDEFINITE(duration)) {
+        NSLog(@"Changed duration to %@", @(CMTimeGetSeconds(duration)));
 
-    if (self.onDidChangeDuration) {
-        self.onDidChangeDuration(@{@"duration": @(CMTimeGetSeconds(duration))});
+        if (self.onDidChangeDuration) {
+            self.onDidChangeDuration(@{@"duration": @(CMTimeGetSeconds(duration))});
+        }
     }
 }
 

--- a/ios/AwsIvsAdapterPlayerView.m
+++ b/ios/AwsIvsAdapterPlayerView.m
@@ -90,7 +90,7 @@ static const NSInteger kDefaultMaxBufferTimeInSeconds = 10;
 }
 
 - (void)player:(IVSPlayer *)player didChangeDuration:(CMTime)duration {
-    if (!CMTIME_IS_INDEFINITE(duration)) {
+    if (!isnan(CMTimeGetSeconds(duration))) {
         NSLog(@"Changed duration to %@", @(CMTimeGetSeconds(duration)));
 
         if (self.onDidChangeDuration) {


### PR DESCRIPTION
If this library is used in conjunction with react-native-reanimated, this library throws a folly exception trying to json parse NaN, this fixes it.

![image](https://user-images.githubusercontent.com/8608314/109545076-45e6df80-7ac0-11eb-98bf-6b3e3d96d3bd.png)
